### PR TITLE
Update access_control_action.jac

### DIFF
--- a/access_control_action/access_control_action.jac
+++ b/access_control_action/access_control_action.jac
@@ -65,6 +65,12 @@ node AccessControlAction :Action: {
         # executes any attached and enabled whatsapp whitelist actions
 
         if(self.enabled) {
+            # if no channel we assume default
+            if(not channel) {
+                # set channel default
+                channel = "default";
+            }
+
             # Check if channel exists in permissions
             if(channel in self.permissions.keys()) {
                  # First check specific action permission


### PR DESCRIPTION
This patch forces the access control action to assume the default channel if the `channel` parameter is an empty string when calling `has_action_access()`.

---

## **Type of Change**

What type of change does this PR introduce? Mark all that apply:

* [x] 🐛 Bug Fix
* [ ] 🚀 Feature Request
* [ ] 🔄 Refactor
* [ ] 📖 Documentation Update
* [ ] 🔧 Other (Please specify):

---

## **Summary**

### **What does this PR address?**

* Ensures consistent behavior in `has_action_access()` by defaulting the `channel` parameter when it is not explicitly set.
* Prevents potential access check failures caused by an empty channel string.

---

## **Description**

### **Bug Fixes**:

* **Bug**: Calling `has_action_access()` with an empty string for `channel` could lead to improper access control behavior.
* **Root Cause**: The method did not handle empty string values for the `channel` parameter, resulting in unexpected logic paths.
* **Resolution**: This patch ensures that if the `channel` is an empty string, the method will automatically fall back to the default channel value.

---

## **Changes Made**

### High-Level Summary:

1. Added logic to check if `channel` is an empty string.
2. If so, assign it to the default channel before proceeding with access checks.

---

## **Checklist**

* [x] Code follows the project’s coding guidelines.
* [ ] Tests have been added or updated for new functionality.
* [ ] Documentation has been updated (if applicable).
* [x] Existing tests pass locally with these changes.
* [x] Any dependencies introduced are justified and documented.

---

## **Steps to Test**

1. Call `has_action_access()` with an empty string for the `channel` argument.
2. Confirm that access logic uses the default channel.
3. Run test suite and ensure all relevant tests pass.

---

## **Additional Context**

N/A

---

## **Questions or Concerns**

None at the moment.

---
